### PR TITLE
httpsプロトコルに対応してみました

### DIFF
--- a/jquery.zip2addr.js
+++ b/jquery.zip2addr.js
@@ -12,7 +12,7 @@
 
 $.fn.zip2addr = function(target){
     var c = {
-		api: 'http://www.google.com/transliterate?langpair=ja-Hira|ja&jsonp=?',
+		api: location.protocol + '//www.google.com/transliterate?langpair=ja-Hira|ja&jsonp=?',
 		prefectureToken: '(東京都|道|府|県)',
 		zipDelimiter: '-'
     }


### PR DESCRIPTION
jQuery.zip2addr、便利に使わせていただいています。
httpsプロトコルのページで使用すると、

「セキュリティで保護された Web ページ コンテンツのみを表示しますか?」

というダイアログが表示されたため、httpsに対応させてみました。
よろしくお願いします。
